### PR TITLE
Ensenso simulation on Gazebo

### DIFF
--- a/launch/ensenso_nx.launch
+++ b/launch/ensenso_nx.launch
@@ -1,26 +1,40 @@
 <?xml version="1.0"?>
 <launch>
-	<arg name="gui_tools" default="true" doc="RViz visualization and rqt dynamic reconfigure window"/>
+	<arg name="gui_tools" default="true" doc="RViz visualization,  rqt dynamic reconfigure and gzclient (if sim=true) window"/>
 	<arg name="model_tf" default="true" doc="3D model visualization and tf"/>
 	<arg name="config_file" default="$(find ensenso_nx)/config/ensenso_nx_params.yaml" doc="YAML file with default configuration. These canbe changed dynamically with dynamic_reconfigure"/>
 	<arg name="namespace" default="ensenso_nx" doc="Namespace for topics and params"/>
+	<arg name="use_sim" default="false" doc="Start gazebo with a default configuration for the ensenso nx35 model" />
 
 	<group if="$(arg model_tf)">
 		<param name="robot_description" command="$(find xacro)/xacro --inorder $(find ensenso_nx)/urdf/single_ensenso_n35.urdf"/>
 
 		<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+			<!-- param name="use_gui" value="$(arg use_sim)" / -->
 			<param name="publish_frequency" value="2" />
 		</node>
 
 		<param name="publish_frequency" value="2" />
 		<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+
+		<!-- No sense if there is no urdf loaded -->
+		<group if="$(arg use_sim)">
+			<node name="spawn_ensenso_in_gazebo" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model ensenso_nx" respawn="false" output="screen" />
+			<include file="$(find gazebo_ros)/launch/empty_world.launch">
+				<arg name="world_name" default="$(find ensenso_nx)/worlds/ensenso_test.world"/>
+				<arg name="paused" value="false"/>
+				<arg name="gui" value="$(arg gui_tools)"/>
+			</include>
+		</group>
 	</group>
 
-	<rosparam ns="$(arg namespace)" command="load" file="$(arg config_file)"/>
-
-	<node ns="$(arg namespace)" pkg="ensenso_nx" type="ensenso_nx" name="ensenso_nx" output="screen" />
+	<group unless="$(arg use_sim)">
+		<rosparam ns="$(arg namespace)" command="load" file="$(arg config_file)"/>
+		<node ns="$(arg namespace)" pkg="ensenso_nx" type="ensenso_nx" name="ensenso_nx" output="screen" />
+	</group>
 
 	<group if="$(arg gui_tools)">
-		<node name="rviz" pkg="rviz" type="rviz" args="-d $(find ensenso_nx)/rviz/ensenso_nx.rviz" />s
+		<node name="rviz" pkg="rviz" type="rviz" args="-d $(find ensenso_nx)/rviz/ensenso_nx.rviz" />
 	</group>
+
 </launch>

--- a/rviz/ensenso_nx.rviz
+++ b/rviz/ensenso_nx.rviz
@@ -6,9 +6,9 @@ Panels:
       Expanded:
         - /Global Options1
         - /Status1
-        - /PointCloud21
-      Splitter Ratio: 0.5
-    Tree Height: 729
+        - /TF1/Frames1/single_ensenso_n35_lens_right1
+      Splitter Ratio: 0.697222233
+    Tree Height: 772
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -31,35 +31,23 @@ Panels:
 Visualization Manager:
   Class: ""
   Displays:
-    - Alpha: 1
-      Autocompute Intensity Bounds: true
-      Autocompute Value Bounds:
-        Max Value: 1.51109731
-        Min Value: 0.920883417
-        Value: true
-      Axis: Z
-      Channel Name: intensity
-      Class: rviz/PointCloud2
-      Color: 255; 255; 255
-      Color Transformer: AxisColor
-      Decay Time: 0
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
       Enabled: true
-      Invert Rainbow: false
-      Max Color: 255; 255; 255
-      Max Intensity: 4096
-      Min Color: 0; 0; 0
-      Min Intensity: 0
-      Name: PointCloud2
-      Position Transformer: XYZ
-      Queue Size: 10
-      Selectable: true
-      Size (Pixels): 3
-      Size (m): 0.00100000005
-      Style: Points
-      Topic: /ensenso_nx/ensenso_cloud
-      Unreliable: false
-      Use Fixed Frame: true
-      Use rainbow: true
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
       Value: true
     - Alpha: 1
       Class: rviz/RobotModel
@@ -71,9 +59,37 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
-      Name: EnsensoN35
-      Robot Description: ensenso_nx_1/robot_description
-      TF Prefix: ensenso_nx_1
+        single_ensenso_n35_body:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        single_ensenso_n35_emitter:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        single_ensenso_n35_focus_cloud:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        single_ensenso_n35_lens_left:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        single_ensenso_n35_lens_right:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
       Update Interval: 0
       Value: true
       Visual Enabled: true
@@ -81,22 +97,22 @@ Visualization Manager:
       Enabled: true
       Frame Timeout: 15
       Frames:
-        All Enabled: true
+        All Enabled: false
         single_ensenso_n35_body:
           Value: true
         single_ensenso_n35_emitter:
+          Value: false
+        single_ensenso_n35_focus_cloud:
           Value: true
         single_ensenso_n35_lens_left:
-          Value: true
+          Value: false
         single_ensenso_n35_lens_right:
-          Value: true
-        single_ensenso_n35_virtual_cloud:
-          Value: true
+          Value: false
         world:
           Value: true
-      Marker Scale: 0.100000001
+      Marker Scale: 0.699999988
       Name: TF
-      Show Arrows: true
+      Show Arrows: false
       Show Axes: true
       Show Names: true
       Tree:
@@ -104,20 +120,50 @@ Visualization Manager:
           single_ensenso_n35_body:
             single_ensenso_n35_emitter:
               {}
+            single_ensenso_n35_focus_cloud:
+              {}
             single_ensenso_n35_lens_left:
               {}
             single_ensenso_n35_lens_right:
               {}
-            single_ensenso_n35_virtual_cloud:
-              {}
       Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: z
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: -999999
+      Min Color: 0; 0; 0
+      Min Intensity: 999999
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.00999999978
+      Style: Points
+      Topic: /single_ensenso_n35/ensenso_cloud
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
       Value: true
   Enabled: true
   Global Options:
-    Background Color: 95; 95; 95
+    Background Color: 48; 48; 48
     Default Light: true
-    Fixed Frame: single_ensenso_n35_body
-    Frame Rate: 10
+    Fixed Frame: world
+    Frame Rate: 30
   Name: root
   Tools:
     - Class: rviz/Interact
@@ -136,34 +182,34 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Class: rviz/ThirdPersonFollower
-      Distance: 2.75802231
+      Class: rviz/Orbit
+      Distance: 2.95059824
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.0599999987
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -0.294460416
-        Y: -0.20473069
-        Z: -2.98023792e-08
+        X: 0.0283026882
+        Y: 0.0398243256
+        Z: 0.119879618
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.0500000007
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.00999999978
-      Pitch: 0.565202177
+      Pitch: 0.430398226
       Target Frame: <Fixed Frame>
-      Value: ThirdPersonFollower (rviz)
-      Yaw: 0.548581898
+      Value: Orbit (rviz)
+      Yaw: 5.31357431
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1027
+  Height: 1056
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000001a80000036bfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006700fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000000280000036b000000e300fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000012f00000373fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002800000373000000b300fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b20000000000000000000000020000064000000171fc0100000002fb0000000a0049006d0061006700650000000000000006400000000000000000fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000039d0000004cfc0100000002fb0000000800540069006d006501000000000000039d000002ff00fffffffb0000000800540069006d00650100000000000004500000000000000000000001ef0000036b00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000396fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006700fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002800000396000000e300fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000379fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002800000379000000b300fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d000002ff00fffffffb0000000800540069006d00650100000000000004500000000000000000000005cd0000039600000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -172,6 +218,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 925
-  X: 993
+  Width: 1853
+  X: 67
   Y: 24

--- a/urdf/ensenso_n35.urdf.xacro
+++ b/urdf/ensenso_n35.urdf.xacro
@@ -1,109 +1,156 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro"
-       name="ensenso_nx">
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="ensenso_nx">
 
-    <!-- Colors -->
-    <material name="Ensenso/Blue">
-        <color rgba="0.1 0.1 1.0 1.0"/>
-    </material>
-    <material name="Ensenso/Grey">
-        <color rgba="0.4 0.4 0.4 1.0"/>
-    </material>
-    <material name="Ensenso/Black">
-        <color rgba="0.05 0.05 0.05 1.0"/>
-    </material>
-    <material name="Ensenso/White">
-        <color rgba="0.9 0.9 0.9 0.6"/>
-    </material>
+<!-- Colors -->
+<material name="Ensenso/Blue">
+	<color rgba="0.1 0.1 1.0 1.0"/>
+</material>
+<material name="Ensenso/Grey">
+	<color rgba="0.4 0.4 0.4 1.0"/>
+</material>
+<material name="Ensenso/Black">
+	<color rgba="0.05 0.05 0.05 1.0"/>
+</material>
+<material name="Ensenso/White">
+	<color rgba="0.9 0.9 0.9 0.6"/>
+</material>
 
-    <xacro:macro name="ensenso_n35" params="name parent *origin">
+<xacro:macro name="ensenso_n35" params="name parent focus_length=1.5 *origin">
 
-        <!-- The Ensenso N35 camera -->
-        <joint name="${parent}_${name}_joint" type="fixed">
-            <xacro:insert_block name="origin"/>
-            <parent link="${parent}" />
-            <child link="${name}_body" />
-        </joint>
-        <link name="${name}_body">
-            <visual>
-                <origin xyz="0.0875 -0.025 -0.026" rpy="0 0 0"/>
-                <geometry>
-                    <mesh filename="package://ensenso_nx/urdf/meshes/N30-602-16.stl" scale="0.001 0.001 0.001"/>
-                </geometry>
-                <material name="Ensenso/Blue"/>
-            </visual>
-            <collision>
-                <origin xyz="0.01 0 0.01" rpy="0 0 0"/>
-                <geometry>
-                    <!-- box size="0.175 0.050 0.052"/ -->
-                    <box size="0.220 0.1 0.1"/>
-                </geometry>
-            </collision>
-        </link>
+	<!-- The Ensenso N35 camera -->
+	<joint name="${parent}_${name}_joint" type="fixed">
+		<xacro:insert_block name="origin"/>
+		<parent link="${parent}" />
+		<child link="${name}_body" />
+	</joint>
+	<link name="${name}_body">
+		<visual>
+			<origin xyz="0.0875 -0.025 -0.026" rpy="0 0 0"/>
+			<geometry>
+				<mesh filename="package://ensenso_nx/urdf/meshes/N30-602-16.stl" scale="0.001 0.001 0.001"/>
+			</geometry>
+			<material name="Ensenso/Blue"/>
+		</visual>
+		<collision>
+			<origin xyz="0.01 0 0.01" rpy="0 0 0"/>
+			<geometry>
+				<box size="0.220 0.1 0.1"/>
+			</geometry>
+		</collision>
+		<inertial>
+			<mass value="0.5" />
+			<origin xyz="0 0 0" rpy="0 0 0"/>
+			<inertia ixx="${0.0833333 * 0.5 * (0.1*0.1 + 0.1*0.1)}" ixy="0.0" ixz="0.0"
+			iyy="${0.0833333 * 0.5 * (0.220*0.220 + 0.1*0.1)}" iyz="0.0"
+			izz="${0.0833333 * 0.5 * (0.220*0.220 + 0.1*0.1)}" />
+		</inertial>
+	</link>
 
-        <!-- Useful reference frames -->
+	<!-- Useful reference frames -->
 
-        <!-- Lens left -->
-        <joint name="${name}_lens_left_joint" type="fixed">
-            <parent link="${name}_body"/>
-            <child link="${name}_lens_left"/>
-            <origin xyz="-0.05 0.0 0.026" rpy="0.0 0.0 0.0"/>
-        </joint>
-        <link name="${name}_lens_left">
-            <visual>
-                <origin xyz="0 0 0" rpy="0 0 0"/>
-                <geometry>
-                    <cylinder length="0.001" radius="0.015"/>
-                </geometry>
-                <material name="Ensenso/White"/>
-            </visual>
-        </link>
+	<!-- Lens left -->
+	<joint name="${name}_lens_left_joint" type="fixed">
+		<parent link="${name}_body"/>
+		<child link="${name}_lens_left"/>
+		<origin xyz="-0.05 0.0 0.026" rpy="0.0 0.0 0.0"/>
+	</joint>
+	<link name="${name}_lens_left">
+		<visual>
+			<origin xyz="0 0 0" rpy="0 0 0"/>
+			<geometry>
+				<cylinder length="0.001" radius="0.015"/>
+			</geometry>
+			<material name="Ensenso/White"/>
+		</visual>
+	</link>
 
-        <!-- Lens right -->
-        <joint name="${name}_lens_right_joint" type="fixed">
-            <parent link="${name}_body"/>
-            <child link="${name}_lens_right"/>
-            <origin xyz="0.05 0.0 0.026" rpy="0.0 0.0 0.0"/>
-        </joint>
-        <link name="${name}_lens_right">
-            <visual>
-                <origin xyz="0 0 0" rpy="0 0 0"/>
-                <geometry>
-                    <cylinder length="0.001" radius="0.015"/>
-                </geometry>
-                <material name="Ensenso/White"/>
-            </visual>
-        </link>
+	<!-- Lens right -->
+	<joint name="${name}_lens_right_joint" type="fixed">
+		<parent link="${name}_body"/>
+		<child link="${name}_lens_right"/>
+		<origin xyz="0.05 0.0 0.026" rpy="0.0 0.0 0.0"/>
+	</joint>
+	<link name="${name}_lens_right">
+		<visual>
+			<origin xyz="0 0 0" rpy="0 0 0"/>
+			<geometry>
+				<cylinder length="0.001" radius="0.015"/>
+			</geometry>
+			<material name="Ensenso/White"/>
+		</visual>
+	</link>
 
-        <!-- Emitter -->
-        <joint name="${name}_emitter_joint" type="fixed">
-            <parent link="${name}_body"/>
-            <child link="${name}_emitter"/>
-            <origin xyz="0.0 0.0 0.026" rpy="0.0 0.0 0.0"/>
-        </joint>
-        <link name="${name}_emitter">
-            <visual>
-                <origin xyz="0 0 0" rpy="0 0 0"/>
-                <geometry>
-                    <cylinder length="0.001" radius="0.022"/>
-                </geometry>
-                <material name="Ensenso/White"/>
-            </visual>
-            <collision>
-                <origin xyz="0 0 0" rpy="0 0 0"/>
-                <geometry>
-                    <cylinder length="0.001" radius="0.015"/>
-                </geometry>
-            </collision>
-        </link>
+	<!-- Emitter -->
+	<joint name="${name}_emitter_joint" type="fixed">
+		<parent link="${name}_body"/>
+		<child link="${name}_emitter"/>
+		<origin xyz="0.0 0.0 0.026" rpy="0.0 0.0 0.0"/>
+	</joint>
+	<link name="${name}_emitter">
+		<visual>
+			<origin xyz="0 0 0" rpy="0 0 0"/>
+			<geometry>
+				<cylinder length="0.001" radius="0.022"/>
+			</geometry>
+			<material name="Ensenso/White"/>
+		</visual>
+		<collision>
+			<origin xyz="0 0 0" rpy="0 0 0"/>
+			<geometry>
+				<cylinder length="0.001" radius="0.015"/>
+			</geometry>
+		</collision>
+	</link>
 
-        <!-- Virtual cloud -->
-        <joint name="${name}_virtual_cloud_joint" type="fixed">
-            <parent link="${name}_body"/>
-            <child link="${name}_virtual_cloud"/>
-            <origin xyz="0.0 0.0 1.5" rpy="3.141592 0.0 0.0"/>
-        </joint>
-        <link name="${name}_virtual_cloud" />
+	<!-- Focus point for several models of N35 -->
+	<joint name="${name}_focus_joint" type="fixed">
+		<parent link="${name}_body"/>
+		<child link="${name}_focus_cloud"/>
+		<origin xyz="0.0 0.0 ${focus_length}" rpy="3.141592 0.0 0.0"/>
+	</joint>
+	<link name="${name}_focus_cloud" />
 
-    </xacro:macro>
+	<gazebo reference="${name}_body">
+		<sensor name="ensenso_camera" type="depth">
+			<!-- openni plugin has the x pointing towards the scene, so rotate to have z -->
+			<pose frame="${name}_body">0.0 0.0 0.0 0.0 -1.5708 0.0</pose>
+			<camera>
+				<horizontal_fov>0.74839718</horizontal_fov>
+				<image>
+					<width>1280</width>
+					<height>1024</height>
+					<format>R8G8B8</format>
+				</image>
+				<clip>
+					<near>0.1</near>
+					<far>10.0</far>
+				</clip>
+				<noise>
+					<type>gaussian</type>
+					<mean>0.5</mean>
+					<stddev>1.0</stddev>
+				</noise>
+			</camera>
+			<plugin name="ensenso_plugin" filename="libgazebo_ros_openni_kinect.so">
+				<baseline>0.1</baseline>
+				<alwaysOn>true</alwaysOn>
+				<!-- Keep this zero, update_rate in the parent <sensor> tag
+				will control the frame rate. -->
+				<updateRate>0.0</updateRate>
+				<cameraName>${name}</cameraName>
+				<imageTopicName>/${name}/image_raw</imageTopicName>
+				<cameraInfoTopicName>/${name}/camera_info</cameraInfoTopicName>
+				<depthImageTopicName>/${name}/image_raw</depthImageTopicName>
+				<depthImageInfoTopicName>/${name}/camera_info</depthImageInfoTopicName>
+				<pointCloudTopicName>/${name}/ensenso_cloud</pointCloudTopicName>
+				<frameName>${name}_body</frameName>
+				<pointCloudCutoff>${focus_length - 0.5}</pointCloudCutoff>
+				<pointCloudCutoffMax>${focus_length + 0.5}</pointCloudCutoffMax>
+			</plugin>
+			<always_on>true</always_on>
+			<update_rate>1.0</update_rate>
+		</sensor>
+	</gazebo>
+
+</xacro:macro>
 </robot>

--- a/urdf/single_ensenso_n35.urdf
+++ b/urdf/single_ensenso_n35.urdf
@@ -1,14 +1,12 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro"
-       name="single_ensenso_n35">
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="single_ensenso_n35">
 
-	<xacro:include filename="$(find ensenso_nx)/urdf/ensenso_n35.urdf.xacro" />
+<xacro:include filename="$(find ensenso_nx)/urdf/ensenso_n35.urdf.xacro" />
 
-    <!-- Set origin link -->
-    <link name="world"/>
+<link name="world"/>
 
-    <xacro:ensenso_n35 name="single_ensenso_n35" parent="world">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-    </xacro:ensenso_n35>
+<xacro:ensenso_n35 name="single_ensenso_n35" parent="world" focus_length="0.9">
+	<origin xyz="0 0 1.0" rpy="3.141592 0 0" />
+</xacro:ensenso_n35>
 
 </robot>

--- a/worlds/ensenso_test.world
+++ b/worlds/ensenso_test.world
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <!-- And something to look at -->
+    <include>
+      <name>gripper</name>
+      <uri>model://pr2_gripper</uri>
+      <pose>-0.85 0.2 0.1 0 0 0</pose>
+    </include>
+  </world>
+</sdf>


### PR DESCRIPTION
Two important additions:

* A parameter to define the focus of the camera (the distance to the box where it's supposed to work). This defaults to 1.0m, but it can be changed depending on the model
* Gazebo plugin for simulation (note that the point cloud cut off is affected by the focus length parameter). Test world file uses the PR2 gripper which is within the gazebo models, see figure below for that test.
** Keep updating the formatting where needed

![screenshot from 2018-06-12 15-49-04](https://user-images.githubusercontent.com/4049053/41294964-9832719e-6e59-11e8-9bab-52488e7f89d3.png)

Still there is not noise that can be added, see [here](https://bitbucket.org/osrf/gazebo/issues/2125/depth-sensor-noise-model), and [here](http://answers.gazebosim.org/question/9946/rgbd-camera-noise-model/) for some follow-up, but it looks that we might need to implement it.

